### PR TITLE
Return font list when uploading fonts via api

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -178,7 +178,10 @@ def api_upload_fonts(upload_type):
         r.table('glyphs').insert(fonts_glyphsets).run(g.rdb_conn)
     except Exception, e:
         return json.dumps({'error': str(e)})
-    return json.dumps({'uid': uuid})
+    return json.dumps({
+        'uuid': uuid,
+        'fonts': [f['full_name'] for f in fontset['after']['ttfs']]
+    })
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When uploading fonts via the api, the response now includes which fonts were uploaded.

```
Before:
{uuid: some-uuid}

After:
{uuid: some-uuid, fonts: [font-Regular, font-Bold]
```