### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ itsdangerous==0.24
 Jinja2==2.10
 jsonschema==2.6.0
 MarkupSafe==1.0
-git+https://github.com/googlei18n/nototools
 peewee==2.10.2
 pymongo==3.5.1
 PyYAML==3.12
@@ -31,3 +30,4 @@ urllib3==1.22
 websocket-client==0.44.0
 Werkzeug==0.12.2
 wheel==0.24.0
+fontdiffenator==0.1.1


### PR DESCRIPTION
- Removed nototools
- Added fontdiffenator

We used to use nototools to retrieve all glyphs within a font. This functionality is now in fontdiffenator.