### PR TITLE
Add before and after labelling to screenshots

### DIFF
--- a/app/templates/screenshot.html
+++ b/app/templates/screenshot.html
@@ -49,4 +49,32 @@
 {% include "page-waterfall.html" %}
 {% endif %}
 
+<script>
+
+function labeller(position) {
+    // place a text label down the right hand margin every 200px
+    // This function is used to tell the viewer which font set is
+    // currently being viewed.
+    // https://github.com/googlefonts/diffbrowsers/issues/10
+    var height = document.body.scrollHeight;
+
+    if (height >= 300) {
+        var i = 0;
+        for (i = 300; i <= height; i += 200) {
+            var label = document.createElement("div");
+            label.style.fontFamily = 'arial';
+            label.style.position = 'absolute';
+            label.style.top = i+'px';
+            label.style.right = '10px';
+            label.style.transform = 'rotate(90deg)';
+            var labelText = document.createTextNode(position);
+            label.appendChild(labelText);
+            document.body.appendChild(label);
+        }
+    }
+}
+
+labeller('{{ font_position.title() }}')
+
+</script>
   {% endblock %}


### PR DESCRIPTION
Fixes https://github.com/googlefonts/diffbrowsers/issues/10



Here's a sample.

![desktop_windows_7_ie_9 0_](https://user-images.githubusercontent.com/7525512/44101337-20426e70-9fdf-11e8-8c38-85c1eb77bb29.gif)

cc @laerm0 
