### PR TITLE
Fixed GoogleFonts.width_families

### DIFF
--- a/Lib/gfregression/downloadfonts.py
+++ b/Lib/gfregression/downloadfonts.py
@@ -72,8 +72,7 @@ class GoogleFonts(object):
             if (string in family and "Condensed" in family) or \
                (string in family and "Expanded" in family):
                    results.append(family)
-        if results:
-            results.insert(0, string)
+        results.insert(0, string)
         return results
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -33,7 +33,7 @@ from settings import (
     FONTS_DIR
 )
 
-__version__ = 4.000
+__version__ = 4.001
 
 app = Flask(__name__, static_url_path='/static')
 


### PR DESCRIPTION
If a user specified a family which doesn't have any sibling width families, it would return an empty list. This pr will include the specified family in the list.