### PR TITLE
Support otf

### DIFF
--- a/Lib/gfregression/__init__.py
+++ b/Lib/gfregression/__init__.py
@@ -383,7 +383,8 @@ def _create_family(paths, dst):
         filename = os.path.basename(path)[:-4]
         family_name = familyname_from_filename(filename)
         style_name = stylename_from_filename(filename)
-        uuid_file = os.path.join(dst, str(uuid.uuid4()) + '.ttf')
+        ext = path[-4:]
+        uuid_file = os.path.join(dst, str(uuid.uuid4()) + ext)
         os.rename(path, uuid_file)
         family.append(uuid_file, family_name, style_name)
     return family

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ certifi==2018.10.15
 chardet==3.0.4
 Click==7.0
 Flask==1.0.2
-fontdiffenator==0.7.16
+fontdiffenator==0.9.0
 fonttools==3.32.0
 idna==2.7
 itsdangerous==1.1.0


### PR DESCRIPTION
- Upgrade to latest fontdiffenator
- When renaming font files to uuids, keep previous extension.